### PR TITLE
if dist is in .gitignore, npm .ignores it.. so it doesnt get publishe…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ node_modules/
 reports/
 coverage/
 
-dist/
 app/
 
 .npmrc


### PR DESCRIPTION
…d... maybe this should be on a postinstall hook?